### PR TITLE
feat: 减少空帧输出 (不能完全排除)

### DIFF
--- a/zsim/sim_progress/ScheduledEvent/__init__.py
+++ b/zsim/sim_progress/ScheduledEvent/__init__.py
@@ -62,6 +62,7 @@ class ScheduledEvent:
     ):
         self.data = data  # ScheduleData in __main__
         self.data.dynamic_buff = dynamic_buff
+        self.data.processed_times = 0
         # self.judge_required_info_dict = data.judge_required_info_dict
         self.action_stack = action_stack
 
@@ -114,6 +115,7 @@ class ScheduledEvent:
                         f"{type(event)}，目前不应存在于 event_list"
                     )
                 elif isinstance(event, Preload.SkillNode | LoadingMission):
+                    # print("instance 分类: Preload.SkillNode | LoadingMission")
                     if event.preload_tick <= self.tick:
                         self.skill_event(event)
                         """
@@ -178,6 +180,7 @@ class ScheduledEvent:
                     )
                 # 代码运行到这一行意味着事件已经被处理完毕，所以要将其从event_list中删除
                 self.data.event_list.remove(event)
+                self.data.processed_times += 1
             # 计算过程中如果又有新的事件生成，则继续循环
             if self.data.event_list:
                 if not self.check_all_event():

--- a/zsim/simulator/simulator_class.py
+++ b/zsim/simulator/simulator_class.py
@@ -178,7 +178,11 @@ class Simulator:
             )
             sce.event_start()
             self.tick += 1
-            print(f"\r{self.tick} ", end="")
+            if sce.data.processed_times > 0:
+                # print(sce.data.processed_times, "events processed", end="")
+                seconds = self.tick // 60
+                frames = self.tick % 60
+                print(f"\r{seconds} 秒 {frames:02d} 帧 ", end="")
 
             if self.tick % 500 == 0 and self.tick != 0:
                 gc.collect()


### PR DESCRIPTION
现在模拟一次 3 分钟要输出 10800 行实在太多了。简单处理了一下空帧的判断，没有 event 时不打印帧数。