### PR TITLE
refix(Character): 添加模块导入失败时的默认处理

### DIFF
--- a/zsim/sim_progress/Character/__init__.py
+++ b/zsim/sim_progress/Character/__init__.py
@@ -85,9 +85,12 @@ def character_factory(
         "sim_cfg": sim_cfg,
     }
     if name in __char_module_map:
-        module_name = __char_module_map[name]
-        module = importlib.import_module(f".{module_name}", package=__name__)
-        character_class: Type[Character] = getattr(module, module_name)
-        return character_class(**char_init_args)
+        try:
+            module_name = __char_module_map[name]
+            module = importlib.import_module(f".{module_name}", package=__name__)
+            character_class: Type[Character] = getattr(module, module_name)
+            return character_class(**char_init_args)
+        except ModuleNotFoundError:
+            return Character(**char_init_args)
     else:
         return Character(**char_init_args)


### PR DESCRIPTION
当字符模块不存在时，现在会返回默认的Character类而不是抛出异常，提高代码的健壮性